### PR TITLE
Kafka tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 MAINTAINER RunAbove <contact@runabove.com>
 
-RUN apk --update add openjdk8-jre=8.92.14-r1 wget bash  && \
+RUN apk --update add openjdk8-jre=8.121.13-r0 wget bash  && \
 	rm -rf /var/cache/apk && \
-	wget -q http://www.eu.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz -O /tmp/kafka.tgz && \
+	wget -q http://www.eu.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz -O /tmp/kafka.tgz && \
 	mkdir -p /opt && tar -xzf /tmp/kafka.tgz -C /opt && \
-	mv /opt/kafka_2.11-0.9.0.1 /opt/kafka && \
-	rm /tmp/kafka.tgz && \
-	mkdir /opt/kafka/data && \
-	chmod +x /opt/kafka/bin/kafka-server-start.sh
+	mv /opt/kafka_2.11-0.10.1.1 /opt/kafka && \
+	rm /tmp/kafka.tgz
 
 ENTRYPOINT ["/opt/kafka/bin/kafka-topics.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM alpine:3.5
 
 MAINTAINER RunAbove <contact@runabove.com>
 
-RUN apk --update add openjdk8-jre=8.121.13-r0 wget bash  && \
+RUN apk --update add ca-certificates wget bash openjdk8-jre python2 py2-pip && \
 	rm -rf /var/cache/apk && \
 	wget -q http://www.eu.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz -O /tmp/kafka.tgz && \
 	mkdir -p /opt && tar -xzf /tmp/kafka.tgz -C /opt && \
 	mv /opt/kafka_2.11-0.10.1.1 /opt/kafka && \
-	rm /tmp/kafka.tgz
+	rm /tmp/kafka.tgz && \
+	pip install --upgrade pip kafka-tools
 
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH /opt/kafka/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apk --update add openjdk8-jre=8.121.13-r0 wget bash  && \
 	mv /opt/kafka_2.11-0.10.1.1 /opt/kafka && \
 	rm /tmp/kafka.tgz
 
-ENTRYPOINT ["/opt/kafka/bin/kafka-topics.sh"]
+ENV PATH /opt/kafka/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [Dockerfile for Apache Kafka topics management](https://www.runabove.com/dbaas-queue.xml)
 
-The Kafka-topics-tools docker image basically contains the official Kafka binaries, but focuses on running the kafka-topics shell script as an entrypoint.
+The Kafka-topics-tools docker image basically contains the official Kafka binaries, but focuses on running the kafka topics related tools.
 Can be used with any standard Kafka cluster, and with OVH DBaaS Queue.
 
 # Installation
@@ -13,14 +13,14 @@ docker build -t ovhcom/queue-kafka-topics-tools .
 
 Usage:
 ```
-docker run --rm ovhcom/queue-kafka-topics-tools <args>
+docker run --rm ovhcom/queue-kafka-topics-tools kafka-topics.sh <args>
 ```
 
 See the [official Kafka documentation](http://kafka.apache.org/documentation.html#basic_ops).
 
 Example:
 ```
-docker run --rm ovhcom/queue-kafka-topics-tools --zookeeper $ZK_URL:2181/$KEY \
+docker run --rm ovhcom/queue-kafka-topics-tools kafka-topics.sh --zookeeper $ZK_URL:2181/$KEY \
 	--create --topic $TOPIC --replication-factor 2 --partitions 15
 ```
 


### PR DESCRIPTION
This PR does the following:
- upgrade Kafka version to the latest stable
- remove the default entrypoint, script to run is up to the user
- install Linkedin's kafka-tools